### PR TITLE
Fix Python3 shebang

### DIFF
--- a/tools/bas2prg.py
+++ b/tools/bas2prg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Frank Buss
 # All rights reserved.

--- a/tools/bin2c.py
+++ b/tools/bin2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Frank Buss
 # All rights reserved.

--- a/tools/png2sprite.py
+++ b/tools/png2sprite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Frank Buss
 # All rights reserved.

--- a/tools/renumber.py
+++ b/tools/renumber.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+
 # Renumber a BASIC PROGRAM.
 # Manage GOTO AND GOSUB Calls too
 


### PR DESCRIPTION
The standard for Python3 shebang lines (the `#!` lines) is to use `/usr/bin/env` to make the path location-agnostic. Python isn't always installed in the same location on various systems (for example, on my mac, it's installed at `/usr/local/bin/python3`). Using `env` allows it to work when Python3 is installed in other locations.