### PR TITLE
Prevent emulator memory dump when converting BAS to PRG

### DIFF
--- a/tools/bas2prg.py
+++ b/tools/bas2prg.py
@@ -50,7 +50,7 @@ for f in os.listdir(args.input):
             bas = input.read()
 
         # add SAVE and exit command, and save as temporary file
-        bas = bas + ('\nSAVE "' + prg + '\nSYS $FFFF\n"').encode('iso-8859-1')
+        bas = bas + ('\nSAVE "' + prg + '\nPOKE $9FB4,0\nSYS $FFFF\n"').encode('iso-8859-1')
         tempFilename = args.input + ".tmp"
         with open(tempFilename, "wb") as output:
             output.write(bas)


### PR DESCRIPTION
I noticed that the demo folder was getting filled with files named `dump.bin`, `dump-1.bin`, etc. I realized that the emulator performs a memory dump when jumped to `$FFFF` by default. By adding a `POKE` command to the appended `SAVE` and `SYS` commands, I disable the memory dump when creating the PRG files.