### PR TITLE
Feature/petdrawx16 compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore binary files: they muts be build during release
+
+*.prg

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS := assembly basic-sprite cc65-audio cc65-sprite
+SUBDIRS := petdrawx16 assembly basic-sprite cc65-audio cc65-sprite
 
 all: $(SUBDIRS)
 	rm -rf release

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ The tools/ directory contains:
 + requirements.txt - Python requirements for the tools. Use with "pip3 install -r requirements.txt"
 
 
+# How to compile asm files
+The Makefile need the acme compiler.
+
+Install the acme compiler from 
+wget https://github.com/meonwax/acme/archive/master.zip
+and the cc65 toolchain (needed for some files)

--- a/petdrawx16/Makefile
+++ b/petdrawx16/Makefile
@@ -1,0 +1,3 @@
+all:
+	acme -f cbm -o petdrawx16.prg petdrawx16.asm
+


### PR DESCRIPTION
1. Added a Makefile to compile petdrax16 with acme compiler
2. Added a note on the acme compiler
3. Added a .gitignore to ignore prg binary files

**Recommeded revision32 of the emulator or higher**

petdrax16 compile and works but a warning is printed during compilation:
> acme -f cbm -o petdrawx16.prg petdrawx16.asm
>  Warning - File petdrawx16.asm, line 5 (Zone <untitled>): Output file already chosen.
