### PR TITLE
Feature/petdrawx16 compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore binary files: they muts be build during release
+
+*.prg

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS := assembly basic-sprite cc65-audio cc65-sprite
+SUBDIRS := petdrawx16 assembly basic-sprite cc65-audio cc65-sprite
 
 all: $(SUBDIRS)
 	rm -rf release

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ The tools/ directory contains:
 + requirements.txt - Python requirements for the tools. Use with "pip3 install -r requirements.txt"
 
 
+# How to compile asm files
+The Makefile need the acme compiler.
+
+Install the acme compiler from 
+wget https://github.com/meonwax/acme/archive/master.zip
+and the cc65 toolchain (needed for some files)

--- a/petdrawx16/Makefile
+++ b/petdrawx16/Makefile
@@ -1,0 +1,3 @@
+all:
+	acme -f cbm -o petdrawx16.prg petdrawx16.asm
+

--- a/petdrawx16/Makefile
+++ b/petdrawx16/Makefile
@@ -1,3 +1,3 @@
 all:
-	acme -f cbm -o petdrawx16.prg petdrawx16.asm
+	acme -f cbm  petdrawx16.asm
 

--- a/petdrawx16/Makefile
+++ b/petdrawx16/Makefile
@@ -1,3 +1,3 @@
 all:
-	acme -f cbm  petdrawx16.asm
+	acme -f cbm -o petdrawx16.prg petdrawx16.asm
 

--- a/petdrawx16/petdrawx16.asm
+++ b/petdrawx16/petdrawx16.asm
@@ -2,7 +2,6 @@
 ;by David Murray 2019
 ;dfwgreencars@gmail.com
 
-!to "PETDRAWX16.PRG",cbm
 
 *=$0801               ;START ADDRESS IS $0801
 VERA_INC=$9F22


### PR DESCRIPTION
New propsed fix for 'Warning - File petdrawx16.asm, line 5 (Zone ): Output file already chosen.'
during the compilation of petdrawx16