### PR TITLE
fixes layer 2 charset overlay

### DIFF
--- a/assembly/mode7-demo.asm
+++ b/assembly/mode7-demo.asm
@@ -38,6 +38,11 @@ loop3:	lda (2),y
 	dex
 	bne loop3
 
+	+vset vreg_lay2 | AUTO_INC_1
+
+	lda #0 ; disabled
+	sta veradat ; 0
+
 	+vset vreg_lay1 | AUTO_INC_1
 
 	lda #7 << 5 | 1; // mode=7, enabled=1


### PR DESCRIPTION
the latest ROM uses layer 2, which results in characters displayed above the graphics
this patch disables layer 2