### PR TITLE
Code updates for rom r37

### DIFF
--- a/cc65-sprite/demo.c
+++ b/cc65-sprite/demo.c
@@ -75,7 +75,8 @@ void main(void)
 
         // Inside address bits 12:5.
         // Set the outside address to increment with each access.
-        vpoke((0x010000 >> 5) & 0xFF, 0x1F5000 + i * 8);
+
+        vpoke((0x010000 >> 5) & 0xFF, 0x1FC00 + i * 8);
 
         // 8 Bits-Per-Pixel mode (sprites can have 256 colors).
         // Inside address bits 16:13 (sprite pattern starts at 0x010000).
@@ -102,12 +103,12 @@ void main(void)
 
     // Copy the balloon sprite data into the video RAM.
     // Set the address to increment with each access.
-    vpoke(balloon[0], 0x110000);
+    vpoke(balloon[0], 0x10000);
     for (i = 0; ++i < 64*64; )
         VERA.data0 = balloon[i];
 
     // Enable the sprites.
-    vpoke(0x01, 0x0F4000);
+    VERA.dc_video |= 0x40;
 
     // Animate those sprites.
     puts("\npress any key to stop.");
@@ -119,7 +120,7 @@ void main(void)
 
         // Update the sprites' y co-ordinates.
         for (i = 0; i < SPRITE_COUNT * 8; i += 8) {
-            vpoke(80 + sin[j], 0x0F5004 + i);
+            vpoke(80 + sin[j], 0x1FC04 + i);
             j += 4;
             if (j > 99)
                 j -= 100;
@@ -132,5 +133,5 @@ void main(void)
     cgetc();
 
     // Disable the sprites.
-    vpoke(0x00, 0x0F4000);
+    VERA.dc_video &=0xbf;
 }


### PR DESCRIPTION
This PR updates the cc65-sprite demo to work with VERA 0.9 in rom r37.

This set of changes was tested with emulator/rom r37 and built with a fork of cc65 with in-progress set of updates for r37: https://github.com/CJLove/cc65/tree/commander-x16