### PR TITLE
Updates to cc65-sprite and cc65-audio for r37 and latest CC65

### DIFF
--- a/cc65-audio/main.c
+++ b/cc65-audio/main.c
@@ -43,7 +43,7 @@ static uint16_t ofs, start;
 
 static void startWrite()
 {
-    vpoke(0, 0x01f1ac);
+    vpoke(0, 0x01fa0c);
 }
 
 static void endWrite()

--- a/cc65-audio/main.c
+++ b/cc65-audio/main.c
@@ -43,12 +43,12 @@ static uint16_t ofs, start;
 
 static void startWrite()
 {
-    vpoke(0, 0x0f100c);
+    vpoke(0, 0x01f1a0c);
 }
 
 static void endWrite()
 {
-    vpoke(15, 0x0f100c);
+    vpoke(15, 0x01fa0c);
 }
 
 static void wait(uint16_t samples)

--- a/cc65-audio/main.c
+++ b/cc65-audio/main.c
@@ -43,7 +43,7 @@ static uint16_t ofs, start;
 
 static void startWrite()
 {
-    vpoke(0, 0x01f1a0c);
+    vpoke(0, 0x01f1ac);
 }
 
 static void endWrite()

--- a/cc65-sprite/demo.c
+++ b/cc65-sprite/demo.c
@@ -108,7 +108,7 @@ void main(void)
         VERA.data0 = balloon[i];
 
     // Enable the sprites.
-    VERA.dc_video |= 0x40;
+    vera_sprites_enable(1);
 
     // Animate those sprites.
     puts("\npress any key to stop.");
@@ -133,5 +133,5 @@ void main(void)
     cgetc();
 
     // Disable the sprites.
-    VERA.dc_video &=0xbf;
+    vera_sprites_enable(0);
 }

--- a/cc65-sprite/demo.c
+++ b/cc65-sprite/demo.c
@@ -76,7 +76,7 @@ void main(void)
         // Inside address bits 12:5.
         // Set the outside address to increment with each access.
 
-        vpoke((0x010000 >> 5) & 0xFF, 0x1FC00 + i * 8);
+        vpoke((0x010000 >> 5) & 0xFF, 0x11FC00 + i * 8);
 
         // 8 Bits-Per-Pixel mode (sprites can have 256 colors).
         // Inside address bits 16:13 (sprite pattern starts at 0x010000).
@@ -103,7 +103,7 @@ void main(void)
 
     // Copy the balloon sprite data into the video RAM.
     // Set the address to increment with each access.
-    vpoke(balloon[0], 0x10000);
+    vpoke(balloon[0], 0x110000);
     for (i = 0; ++i < 64*64; )
         VERA.data0 = balloon[i];
 

--- a/cc65-sprite/demo.c
+++ b/cc65-sprite/demo.c
@@ -75,7 +75,8 @@ void main(void)
 
         // Inside address bits 12:5.
         // Set the outside address to increment with each access.
-        vpoke((0x010000 >> 5) & 0xFF, 0x1F5000 + i * 8);
+
+        vpoke((0x010000 >> 5) & 0xFF, 0x1FC00 + i * 8);
 
         // 8 Bits-Per-Pixel mode (sprites can have 256 colors).
         // Inside address bits 16:13 (sprite pattern starts at 0x010000).
@@ -102,12 +103,12 @@ void main(void)
 
     // Copy the balloon sprite data into the video RAM.
     // Set the address to increment with each access.
-    vpoke(balloon[0], 0x110000);
+    vpoke(balloon[0], 0x10000);
     for (i = 0; ++i < 64*64; )
         VERA.data0 = balloon[i];
 
     // Enable the sprites.
-    vpoke(0x01, 0x0F4000);
+    VERA.dc_video |= 0x40;
 
     // Animate those sprites.
     puts("\npress any key to stop.");
@@ -119,7 +120,7 @@ void main(void)
 
         // Update the sprites' y co-ordinates.
         for (i = 0; i < SPRITE_COUNT * 8; i += 8) {
-            vpoke(80 + sin[j], 0x0F5004 + i);
+            vpoke(80 + sin[j], 0x1FC04 + i);
             j += 4;
             if (j > 99)
                 j -= 100;
@@ -132,5 +133,5 @@ void main(void)
     cgetc();
 
     // Disable the sprites.
-    vpoke(0x00, 0x0F4000);
+    VERA.dc_video &=0xbf;
 }


### PR DESCRIPTION
With these changes built using the latest CC65 the sprite and audio demos work with Emulator/rom version r37.