### PR TITLE
Use subprocess in bas2prg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SUBDIRS := petdrawx16 assembly basic-sprite cc65-audio cc65-sprite
 
+EMULATOR ?= ../x16-emulator/x16emu
+
 all: $(SUBDIRS)
 	rm -rf release
 	mkdir -p release/basic
@@ -12,7 +14,7 @@ all: $(SUBDIRS)
 	cp basic-sprite/smiley.bas release/basic
 	cp basic/* release/basic
 	cp "layer demo/layer-demo.bas" release/basic
-	./tools/bas2prg.py ../x16-emulator/x16emu ./release/basic ./release/PRG
+	./tools/bas2prg.py "${EMULATOR}" ./release/basic ./release/PRG
 	cd release/PRG ; python -c 'import os, sys; [os.rename(a, a.upper()) for a in sys.argv[1:]]' *
 
 clean:

--- a/tools/bas2prg.py
+++ b/tools/bas2prg.py
@@ -27,6 +27,7 @@
 import sys
 import argparse
 import os
+import subprocess
 import codecs
 
 # parse arguments
@@ -56,7 +57,7 @@ for f in os.listdir(args.input):
             output.write(bas)
 
         # call the emulator to create the PRG file
-        os.system(args.emulator + " -bas " + tempFilename)
+        subprocess.run([args.emulator, "-bas", tempFilename])
         
         # copy output to the final directoy
         os.rename(prg, prgFilename)


### PR DESCRIPTION
This makes a small change to the python script `tools/bas2prg.py`, replacing the call to `os.system` with `subprocess.run`.

I was attempting to build the demos on my Windows machine (I've mostly used my mac with this project before) and was having issues with this line. I'm using MSys2 (and MinGW) for Makefile support, but `os.system` runs using `cmd.exe`. The problem is that `cmd.exe` doesn't handle forward slashes in paths, so the path specified in the Makefile causes problems. Switching to `subprocess.run` avoids this issue by not calling any shell (since `shell=False`), letting the OS handle the forward slashes as it normally does. Making this change also has the advantage of better handling spaces in the path.

I also went ahead and added a variable to the makefile to allow it to work when the emulator is located somewhere else. This can be utilized by calling make using `EMULATOR=/path/to/x16emu make`.