### PR TITLE
Fix compilation, add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           cd ..
           gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emulator
-          ls x16-emulator
+          cd x16-emulator
+          tar --strip-components=1 -zxf *
           ./x16-emulator/x16emu -version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build Demos
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install Dependencies
+        run: |
+          pip install -r tools/requirements.txt
+          cd ..
+          sudo apt-get install -y make build-essential subversion
+          git clone https://github.com/cc65/cc65.git
+          cd cc65
+          make -j
+          sudo make install
+          cd ..
+          svn checkout https://svn.code.sf.net/p/acme-crossass/code-0/trunk acme-crossass-code-0
+          cd acme-crossass-code-0/src
+          make -j 
+          sudo make install
+          cd ..
+          gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emu
+      - name: Build ROM
+        run: |
+          make
+      - name: Archive Build Result
+        uses: actions/upload-artifact@v3
+        with:
+          name: X16 Demos
+          path: release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install ACME
         run: |
           cd ..
-          svn checkout https://svn.code.sf.net/p/acme-crossass/code-0/trunk acme-crossass-code-0
+          svn checkout svn://svn.code.sf.net/p/acme-crossass/code-0/trunk acme-crossass-code-0
           cd acme-crossass-code-0/src
           make -j
           sudo make install
@@ -36,8 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Demos
-        run: |
-          make
+        run: make
       - name: Archive Build Result
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,16 +32,12 @@ jobs:
       - name: Download latest X16-Emu
         run: |
           cd ..
-          gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emu
-          pwd
-          ls -l .
+          gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emulator
+          x16-emulator/x16emu --version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Demos
-        run: |
-          pwd
-          ls -l ..
-          make
+        run: make
       - name: Archive Build Result
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emulator
           cd x16-emulator
           tar --strip-components=1 -zxf *
-          ./x16-emulator/x16emu -version
+          ./x16emu -version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Demos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           cd ..
           gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emulator
           cd x16-emulator
-          tar --strip-components=1 -zxf *
+          tar --strip-components=1 -xf x16emu.tar.gz
           ./x16emu -version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           cd ..
           gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emulator
-          x16-emulator/x16emu --version
+          ls x16-emulator
+          ./x16-emulator/x16emu -version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Demos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - name: Install general dependencies
+      - name: Install General Dependencies
         run: sudo apt-get install -y make build-essential subversion libsdl2-dev
       - name: Install Python Dependencies
         run: pip install -r tools/requirements.txt
@@ -29,7 +29,7 @@ jobs:
           cd acme-crossass-code-0/src
           make -j
           sudo make install
-      - name: Download latest X16-Emu
+      - name: Download Latest X16-Emu
         run: |
           cd ..
           gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emulator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,15 @@ jobs:
         run: |
           cd ..
           gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emu
+          pwd
+          ls -l .
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Demos
-        run: make
+        run: |
+          pwd
+          ls -l ..
+          make
       - name: Archive Build Result
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,23 +11,31 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - name: Install Dependencies
+      - name: Install general dependencies
+        run: sudo apt-get install -y make build-essential subversion libsdl2-dev
+      - name: Install Python Dependencies
+        run: pip install -r tools/requirements.txt
+      - name: Install cc65
         run: |
-          pip install -r tools/requirements.txt
           cd ..
-          sudo apt-get install -y make build-essential subversion
           git clone https://github.com/cc65/cc65.git
           cd cc65
           make -j
           sudo make install
+      - name: Install ACME
+        run: |
           cd ..
           svn checkout https://svn.code.sf.net/p/acme-crossass/code-0/trunk acme-crossass-code-0
           cd acme-crossass-code-0/src
-          make -j 
+          make -j
           sudo make install
+      - name: Download latest X16-Emu
+        run: |
           cd ..
           gh run download -R commanderx16/x16-emulator -n "X16-Emu Linux 64-bit" --dir x16-emu
-      - name: Build ROM
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Demos
         run: |
           make
       - name: Archive Build Result

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 # Ignore binary files: they muts be build during release
-
 *.prg
+
+# output of .png to .inc converter and BASIC makefile
+*.inc
+smiley.bas
+
+# build folder
+release/
+
+# IDE files
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 SUBDIRS := petdrawx16 assembly basic-sprite cc65-audio cc65-sprite
 
 # determine whether to use python3 or python command
-CHECK_CMD=$(shell python3 -V)
-ifeq (, $(CHECK_CMD))
-	CHECK_CMD=$(shell python -V)
-	ifeq (, $(CHECK_CMD))
+ifeq (, $(shell python3 -V))
+	ifeq (, $(shell python -V))
 		$(error "Neither Python nor Python3 not found in $(PATH)")
 	else
 		PYTHON=python

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
 SUBDIRS := petdrawx16 assembly basic-sprite cc65-audio cc65-sprite
 
+# determine whether to use python3 or python command
+PYTHON=$(shell command -v python3)
+ifeq (, $(PYTHON))
+	PYTHON=$(shell command -v python)
+	ifeq (, $(PYTHON))
+		$(error "Neither Python nor Python3 not found in $(PATH)")
+	endif
+endif
+
 all: $(SUBDIRS)
 	rm -rf release
 	mkdir -p release/basic
@@ -13,7 +22,7 @@ all: $(SUBDIRS)
 	cp basic/* release/basic
 	cp "layer demo/layer-demo.bas" release/basic
 	./tools/bas2prg.py ../x16-emulator/x16emu ./release/basic ./release/PRG
-	cd release/PRG ; python -c 'import os, sys; [os.rename(a, a.upper()) for a in sys.argv[1:]]' *
+	cd release/PRG ; $(PYTHON) -c 'import os, sys; [os.rename(a, a.upper()) for a in sys.argv[1:]]' *
 
 clean:
 	rm -rf release

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 SUBDIRS := petdrawx16 assembly basic-sprite cc65-audio cc65-sprite
 
 # determine whether to use python3 or python command
-PYTHON=$(shell command -v python3)
-ifeq (, $(PYTHON))
-	PYTHON=$(shell command -v python)
-	ifeq (, $(PYTHON))
+CHECK_CMD=$(shell python3 -V)
+ifeq (, $(CHECK_CMD))
+	CHECK_CMD=$(shell python -V)
+	ifeq (, $(CHECK_CMD))
 		$(error "Neither Python nor Python3 not found in $(PATH)")
+	else
+		PYTHON=python
 	endif
+else
+	PYTHON=python3
 endif
 
 all: $(SUBDIRS)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-C, Asssembly and B.A.S.I.C. v2 examples for commander-x16
+# C, Asssembly and B.A.S.I.C. v2 examples for commander-x16
+
+[![Build Status](https://github.com/commanderx16/x16-demo/actions/workflows/build.yml/badge.svg)](https://github.com/commanderx16/x16-demo/actions/workflows/build.yml)
+[![Contributors](https://img.shields.io/github/contributors/commanderx16/x16-demo.svg)](https://github.com/commanderx16/x16-demo/graphs/contributors)
 
 Basic examples are collected from Facebook group
 
@@ -17,7 +20,7 @@ The tools/ directory contains:
 + requirements.txt - Python requirements for the tools. Use with "pip3 install -r requirements.txt"
 
 
-# How to compile asm files
+## How to compile asm files
 The Makefile need the acme compiler.
 
 Install the acme compiler from 

--- a/cc65-audio/main.c
+++ b/cc65-audio/main.c
@@ -95,7 +95,7 @@ char* readWideString(uint16_t* pos)
         buf[i++] = wc;
         if (wc == 0) break;
     }
-    return buf;
+    return (char*) buf;
 }
 
 void play()

--- a/cc65-audio/main.c
+++ b/cc65-audio/main.c
@@ -31,12 +31,8 @@
 
 #include "vgm.inc"
 
-struct YM2151_t {
-    uint8_t reg;
-    uint8_t data;
-};
-
-#define YM2151 (*(volatile struct YM2151_t*) 0x9fe0)
+//note: YM2151 struct is defined by cc65 in cx16.h
+//since commit a5e69e7.
 
 static uint8_t run;
 static uint16_t ofs, start;

--- a/tools/bas2prg.py
+++ b/tools/bas2prg.py
@@ -40,7 +40,7 @@ args = parser.parse_args()
 for f in os.listdir(args.input):
     if f.upper().endswith('.BAS'):
         basFilename = args.input + "/" + f
-        print("converting file %s..." % basFilename)
+        print("converting file %s..." % basFilename, flush=True)
         prg = f.upper()[:-4] + ".PRG"
         prgFilename = args.output + "/" + prg
         prg = prg + ".TMP"

--- a/tools/bas2prg.py
+++ b/tools/bas2prg.py
@@ -56,7 +56,8 @@ for f in os.listdir(args.input):
             output.write(bas)
 
         # call the emulator to create the PRG file
-        os.system(args.emulator + " -bas " + tempFilename)
+        # do not require sound output (needed for CI)
+        os.system(args.emulator + "-audio sound -bas " + tempFilename)
         
         # copy output to the final directoy
         os.rename(prg, prgFilename)

--- a/tools/bas2prg.py
+++ b/tools/bas2prg.py
@@ -57,7 +57,7 @@ for f in os.listdir(args.input):
 
         # call the emulator to create the PRG file
         # do not require sound output (needed for CI)
-        os.system(args.emulator + "-audio sound -bas " + tempFilename)
+        os.system(args.emulator + " -audio sound -bas " + tempFilename)
         
         # copy output to the final directoy
         os.rename(prg, prgFilename)

--- a/tools/bas2prg.py
+++ b/tools/bas2prg.py
@@ -57,7 +57,7 @@ for f in os.listdir(args.input):
 
         # call the emulator to create the PRG file
         # do not require sound output (needed for CI)
-        os.system(args.emulator + " -audio sound -bas " + tempFilename)
+        os.system(args.emulator + " -sound none -bas " + tempFilename)
         
         # copy output to the final directoy
         os.rename(prg, prgFilename)

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,3 @@
 Click>=7.0
-numpy>=1.16.0 
+numpy>=1.16.0
+Pillow>=8.0.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,2 @@
-Click==7.0
+Click>=7.0
+numpy>=1.16.0 


### PR DESCRIPTION
* fixes compile error in cc65-audio (#124)
* updates `requirements.txt` to not have ancient versions **and** all actually needed dependencies (Pillow + numpy)
* Add CI to build all demos on a Ubuntu machine with latest emulator
* Add badges to `README`

cc65-audio demo outputs audio, but in my virtual machine the audio was slightly stuttering -- not sure if the program itself needs to be updated more or if I just have bad performance. For now, I just wanted this PR to have minimal impact on the actual application code that does not go beyond "fix compilation".

I've also tested the compiled programs in the latest emulator at random.

Compiled cc65-sprite demo runs.

![grafik](https://user-images.githubusercontent.com/26485477/201222070-12ec112a-b952-4c8d-bb74-3d757a2d3066.png)

Affine demo runs.

![grafik](https://user-images.githubusercontent.com/26485477/201222451-566e6cc5-0bf8-4cdf-8984-e3231a1eb9a0.png)

Demos that are not running (basically blank screen after some optional intro screen): snake, layer, frog, balls, ...

However, other PRs like #115 and #122 may fix some of these.

Supersedes #108.